### PR TITLE
Set the DATABASES dict rather than assigning to it.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,11 +11,11 @@ Usage
 
 Configure your database in ``settings.py`` from ``DATABASE_URL``::
 
-    DATABASES['default'] = dj_database_url.config()
+    DATABASES = {'default': dj_database_url.config()}
 
 Parse an arbitrary Database URL::
 
-    DATABASES['default'] = dj_database_url.parse('postgres://...')
+    DATABASES = {'default': dj_database_url.parse('postgres://...')}
 
 Supported databases
 -------------------


### PR DESCRIPTION
Basically just to allow more copy-pasting from the README. I know it should be obvious but it was instinct to copy verbatim.
