### PR TITLE
Support the 'postgresql' url scheme.

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -40,7 +40,7 @@ def parse(url):
         'PORT': url.port,
     })
 
-    if url.scheme == 'postgres':
+    if url.scheme == 'postgres' or url.scheme == 'postgresql':
         config['ENGINE'] = 'django.db.backends.postgresql_psycopg2'
 
     if url.scheme == 'postgis':


### PR DESCRIPTION
OpenShift databases are found using the OPENSHIFT_DB_URL environment variable.

This has the format 'postgresql://admin:xxx@xx.xx.xx.xx:xxxx'
