### PR TITLE
This patch fixes the way urls are parsed to support blank passwords, usernames, hostnames...etc. This is particularly important in dev environments with Postgres, where blank passwords currently don't work

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -55,11 +55,11 @@ def parse(url):
 
     # Update with environment configuration.
     config.update({
-        'NAME': path,
-        'USER': url.username,
-        'PASSWORD': url.password,
-        'HOST': url.hostname,
-        'PORT': url.port,
+        'NAME': path or '',
+        'USER': url.username or '',
+        'PASSWORD': url.password or '',
+        'HOST': url.hostname or '',
+        'PORT': url.port or '',
     })
 
     if url.scheme in SCHEMES:


### PR DESCRIPTION
Fixes a bug with postgres, where blank passwords weren't supported.
