### PR TITLE
add support for local databases, without a hostname

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -74,9 +74,10 @@ def parse(url):
         'NAME': path,
         'USER': url.username,
         'PASSWORD': url.password,
-        'HOST': url.hostname,
         'PORT': url.port,
     })
+    if url.hostname:
+        config['HOST'] = url.hostname
 
     if url.scheme in SCHEMES:
         config['ENGINE'] = SCHEMES[url.scheme]

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -48,6 +48,17 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['PASSWORD'] == '69772142'
         assert url['PORT'] is None
 
+    def test_nohost_parsing(self):
+        url = 'postgres://john@/some_db'
+        url = dj_database_url.parse(url)
+
+        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        assert url['NAME'] == 'some_db'
+        assert 'HOST' not in url
+        assert url['USER'] == 'john'
+        assert url['PASSWORD'] is None
+        assert url['PORT'] is None
+
     def test_database_url(self):
         a = dj_database_url.config()
         assert not a


### PR DESCRIPTION
Useful for PostgreSQL databases, deployed locally.
