### PR TITLE
Ability to set different engine

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -29,7 +29,7 @@ SCHEMES = {
 }
 
 
-def config(env=DEFAULT_ENV, default=None):
+def config(env=DEFAULT_ENV, default=None, engine=None):
     """Returns configured DATABASE dictionary from DATABASE_URL."""
 
     config = {}
@@ -37,12 +37,12 @@ def config(env=DEFAULT_ENV, default=None):
     s = os.environ.get(env, default)
 
     if s:
-        config = parse(s)
+        config = parse(s, engine)
 
     return config
 
 
-def parse(url):
+def parse(url, engine=None):
     """Parses a database URL."""
 
     if url == 'sqlite://:memory:':
@@ -78,7 +78,9 @@ def parse(url):
         'PORT': url.port,
     })
 
-    if url.scheme in SCHEMES:
+    if engine:
+        config['ENGINE'] = engine
+    elif url.scheme in SCHEMES:
         config['ENGINE'] = SCHEMES[url.scheme]
 
     return config

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -12,9 +12,6 @@ POSTGIS_URL = 'postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compu
 
 class DatabaseTestSuite(unittest.TestCase):
 
-    def test_truth(self):
-        assert True
-
     def test_postgres_parsing(self):
         url = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn'
         url = dj_database_url.parse(url)
@@ -49,6 +46,7 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['PORT'] is None
 
     def test_database_url(self):
+        del os.environ['DATABASE_URL']
         a = dj_database_url.config()
         assert not a
 
@@ -77,8 +75,19 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['ENGINE'] == 'django.db.backends.sqlite3'
         assert url['NAME'] == ':memory:'
 
+    def test_parse_engine_setting(self):
+        engine = 'django_mysqlpool.backends.mysqlpool'
+        url = 'mysql://bea6eb025ca0d8:69772142@us-cdbr-east.cleardb.com/heroku_97681db3eff7580?reconnect=true'
+        url = dj_database_url.parse(url, engine)
 
+        assert url['ENGINE'] == engine
 
+    def test_config_engine_setting(self):
+        engine = 'django_mysqlpool.backends.mysqlpool'
+        os.environ['DATABASE_URL'] = 'mysql://bea6eb025ca0d8:69772142@us-cdbr-east.cleardb.com/heroku_97681db3eff7580?reconnect=true'
+        url = dj_database_url.config(engine=engine)
+
+        assert url['ENGINE'] == engine
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I think the ability to specify database engine would be nice for things like MySQL connection pool (https://github.com/smartfile/django-mysqlpool) - makes code a little cleaner than manipulating DATABASES dict after url is parsed or something like that.
