### PR TITLE
Added support for percent-encoded Postgres paths.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,21 +35,24 @@ Parse an arbitrary Database URL::
 URL schema
 ----------
 
-+-------------+--------------------------------------------+---------------------------------------------+
-| Engine      | Django Backend                             | URL                                         |
-+=============+============================================+=============================================+
-| PostgreSQL  | ``django.db.backends.postgresql_psycopg2`` | ``postgres://USER:PASSWORD@HOST:PORT/NAME`` |
-+-------------+--------------------------------------------+---------------------------------------------+
-| PostGIS     | ``django.contrib.gis.db.backends.postgis`` | ``postgis://USER:PASSWORD@HOST:PORT/NAME``  |
-+-------------+--------------------------------------------+---------------------------------------------+
-| MySQL       | ``django.db.backends.mysql``               | ``mysql://USER:PASSWORD@HOST:PORT/NAME``    |
-+-------------+--------------------------------------------+---------------------------------------------+
-| MySQL (GIS) | ``django.contrib.gis.db.backends.mysql``   | ``mysqlgis://USER:PASSWORD@HOST:PORT/NAME`` |
-+-------------+--------------------------------------------+---------------------------------------------+
-| SQLite      | ``django.db.backends.sqlite3``             | ``sqlite:///PATH`` [1]_                     |
-+-------------+--------------------------------------------+---------------------------------------------+
++-------------+--------------------------------------------+--------------------------------------------------+
+| Engine      | Django Backend                             | URL                                              |
++=============+============================================+==================================================+
+| PostgreSQL  | ``django.db.backends.postgresql_psycopg2`` | ``postgres://USER:PASSWORD@HOST:PORT/NAME`` [1]_ |
++-------------+--------------------------------------------+--------------------------------------------------+
+| PostGIS     | ``django.contrib.gis.db.backends.postgis`` | ``postgis://USER:PASSWORD@HOST:PORT/NAME``       |
++-------------+--------------------------------------------+--------------------------------------------------+
+| MySQL       | ``django.db.backends.mysql``               | ``mysql://USER:PASSWORD@HOST:PORT/NAME``         |
++-------------+--------------------------------------------+--------------------------------------------------+
+| MySQL (GIS) | ``django.contrib.gis.db.backends.mysql``   | ``mysqlgis://USER:PASSWORD@HOST:PORT/NAME``      |
++-------------+--------------------------------------------+--------------------------------------------------+
+| SQLite      | ``django.db.backends.sqlite3``             | ``sqlite:///PATH`` [2]_                          |
++-------------+--------------------------------------------+--------------------------------------------------+
 
-.. [1] SQLite connects to file based databases. The same URL format is used, omitting
+.. [1] With PostgreSQL, you can also use unix domain socket paths with
+       `percent encoding <http://www.postgresql.org/docs/9.2/interactive/libpq-connect.html#AEN38162>`_:
+       ``postgres://%2Fvar%2Flib%2Fpostgresql/dbname``.
+.. [2] SQLite connects to file based databases. The same URL format is used, omitting
        the hostname, and using the "file" portion as the filename of the database.
        This has the effect of four slashes being present for an absolute file path:
        ``sqlite:////full/path/to/your/database/file.sqlite``.

--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -70,17 +70,22 @@ def parse(url, engine=None):
     path = url.path[1:]
     path = path.split('?', 2)[0]
 
-    # if we are using sqlite and we have no path, then assume we
+    # If we are using sqlite and we have no path, then assume we
     # want an in-memory database (this is the behaviour of sqlalchemy)
     if url.scheme == 'sqlite' and path == '':
         path = ':memory:'
+
+    # Handle postgres percent-encoded paths.
+    hostname = url.hostname or ''
+    if '%2f' in hostname.lower():
+        hostname = hostname.replace('%2f', '/').replace('%2F', '/')
 
     # Update with environment configuration.
     config.update({
         'NAME': path or '',
         'USER': url.username or '',
         'PASSWORD': url.password or '',
-        'HOST': url.hostname or '',
+        'HOST': hostname,
         'PORT': url.port or '',
     })
 

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -23,6 +23,17 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['PASSWORD'] == 'wegauwhgeuioweg'
         assert url['PORT'] == 5431
 
+    def test_postgres_unix_socket_parsing(self):
+        url = 'postgres://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn'
+        url = dj_database_url.parse(url)
+
+        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        assert url['NAME'] == 'd8r82722r2kuvn'
+        assert url['HOST'] == '/var/run/postgresql'
+        assert url['USER'] == ''
+        assert url['PASSWORD'] == ''
+        assert url['PORT'] == ''
+
     def test_postgis_parsing(self):
         url = 'postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn'
         url = dj_database_url.parse(url)


### PR DESCRIPTION
This allows the user to specify unix domain sockets as host.

Example: `postgresql://%2Fvar%2Flib%2Fpostgresql/dbname`

Reference: http://www.postgresql.org/docs/9.2/interactive/libpq-connect.html#AEN38162
