### PR TITLE
Remove Travis CI unsupported python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.5
   - 2.6
   - 2.7
   - 3.2


### PR DESCRIPTION
Per docs http://docs.travis-ci.com/user/languages/python/

> Travis CI support Python versions 2.6, 2.7, 3.2 and 3.3
