### PR TITLE
Add urldecode colons for cloudsql

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ URL schema
 +-------------+-----------------------------------------------+--------------------------------------------------+
 | MSSQL       | ``sql_server.pyodbc``                         | ``mssql://USER:PASSWORD@HOST:PORT/NAME``         |
 +-------------+-----------------------------------------------+--------------------------------------------------+
-| MySQL       | ``django.db.backends.mysql``                  | ``mysql://USER:PASSWORD@HOST:PORT/NAME``         |
+| MySQL       | ``django.db.backends.mysql``                  | ``mysql://USER:PASSWORD@HOST:PORT/NAME`` [1]_    |
 +-------------+-----------------------------------------------+--------------------------------------------------+
 | MySQL (GIS) | ``django.contrib.gis.db.backends.mysql``      | ``mysqlgis://USER:PASSWORD@HOST:PORT/NAME``      |
 +-------------+-----------------------------------------------+--------------------------------------------------+
@@ -81,9 +81,9 @@ URL schema
 | Redshift    | ``django_redshift_backend``                   | ``redshift://USER:PASSWORD@HOST:PORT/NAME``      |
 +-------------+-----------------------------------------------+--------------------------------------------------+
 
-.. [1] With PostgreSQL, you can also use unix domain socket paths with
+.. [1] With PostgreSQL or CloudSQL, you can also use unix domain socket paths with
        `percent encoding <http://www.postgresql.org/docs/9.2/interactive/libpq-connect.html#AEN38162>`_:
-       ``postgres://%2Fvar%2Flib%2Fpostgresql/dbname``.
+       ``postgres://%2Fvar%2Flib%2Fpostgresql/dbname``, ``mysql://uf07k1i6d8ia0v@%2fcloudsql%2fec2-107-21-253-135%3acompute-1/d8r82722r2kuvn``.
 .. [2] SQLite connects to file based databases. The same URL format is used, omitting
        the hostname, and using the "file" portion as the filename of the database.
        This has the effect of four slashes being present for an absolute file path:

--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -102,14 +102,14 @@ def parse(url, engine=None, conn_max_age=0, ssl_require=False):
 
     # Handle postgres percent-encoded paths.
     hostname = url.hostname or ''
-    if '%2f' in hostname.lower():
+    if any(urldecode_char in hostname.lower() for urldecode_char in ['%2f', '%2a']):
         # Switch to url.netloc to avoid lower cased paths
         hostname = url.netloc
         if "@" in hostname:
             hostname = hostname.rsplit("@", 1)[1]
         if ":" in hostname:
             hostname = hostname.split(":", 1)[0]
-        hostname = hostname.replace('%2f', '/').replace('%2F', '/')
+        hostname = hostname.replace('%2f', '/').replace('%2F', '/').replace('%3a', ':').replace('%3A', ':')
 
     # Lookup specified engine.
     engine = SCHEMES[url.scheme] if engine is None else engine

--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -102,6 +102,7 @@ def parse(url, engine=None, conn_max_age=0, ssl_require=False):
 
     # Handle postgres percent-encoded paths.
     hostname = url.hostname or ''
+    # %2f - / character, %3a - : character
     if any(urldecode_char in hostname.lower() for urldecode_char in ['%2f', '%3a']):
         # Switch to url.netloc to avoid lower cased paths
         hostname = url.netloc

--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -102,7 +102,7 @@ def parse(url, engine=None, conn_max_age=0, ssl_require=False):
 
     # Handle postgres percent-encoded paths.
     hostname = url.hostname or ''
-    if any(urldecode_char in hostname.lower() for urldecode_char in ['%2f', '%2a']):
+    if any(urldecode_char in hostname.lower() for urldecode_char in ['%2f', '%3a']):
         # Switch to url.netloc to avoid lower cased paths
         hostname = url.netloc
         if "@" in hostname:

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -31,6 +31,16 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['PASSWORD'] == 'wegauwhgeuioweg'
         assert url['PORT'] == 5431
 
+    def test_cloudsql_unix_socket_parsing(self):
+        url = 'mysql://uf07k1i6d8ia0v@%2fcloudsql%2fec2-107-21-253-135%3acompute-1/d8r82722r2kuvn'
+        url = dj_database_url.parse(url)
+        assert url['ENGINE'] == 'django.db.backends.mysql'
+        assert url['NAME'] == 'd8r82722r2kuvn'
+        assert url['HOST'] == '/cloudsql/ec2-107-21-253-135:compute-1'
+        assert url['USER'] == 'uf07k1i6d8ia0v'
+        assert url['PASSWORD'] == ''
+        assert url['PORT'] == ''
+
     def test_postgres_unix_socket_parsing(self):
         url = 'postgres://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn'
         url = dj_database_url.parse(url)


### PR DESCRIPTION
Adds support for colons in UNIX socket path. 

Use case: cloudsql sockets 

Shameless copypasta from pr by @jdp

See also: #66, #67 