### PR TITLE
Clarifies requirement for url encoding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,11 +52,11 @@ request. Use ``None`` for unlimited persistent connections.
 
 Strings passed to ``dj_database_url`` must actually be valid URLs; in
 particular, special characters must be url-encoded. The following url will raise
-a ``ValueError``
+a ``ValueError``::
 
     postgres://user:p#ssword!@localhost/foobar
 
-and should instead be passed as
+and should instead be passed as::
 
     postgres://user:p%23ssword!@localhost/foobar
 

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,16 @@ and is available in Django 1.6+. If you do not set a value, it will default to `
 which is Django's historical behavior of using a new database connection on each
 request. Use ``None`` for unlimited persistent connections.
 
+Strings passed to ``dj_database_url`` must actually be valid URLs; in
+particular, special characters must be url-encoded. The following url will raise
+a ``ValueError``
+
+    postgres://user:p#ssword!@localhost/foobar
+
+and should instead be passed as
+
+    postgres://user:p%23ssword!@localhost/foobar
+
 URL schema
 ----------
 

--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -85,7 +85,13 @@ def parse(url, engine=None, conn_max_age=0, ssl_require=False):
     # otherwise parse the url as normal
     config = {}
 
-    url = urlparse.urlparse(url)
+    try:
+        url = urlparse.urlparse(url)
+    except ValueError:
+        raise ValueError(
+            'This string is not a valid url, possibly because the username or '
+            'password is not url-encoded.'
+        )
 
     # Split query strings from path.
     path = url.path[1:]

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ and is available in Django 1.6+. If you do not set a value, it will default to `
 which is Django's historical behavior of using a new database connection on each
 request. Use ``None`` for unlimited persistent connections.
 
-Strings passed to `dj_database_url` must actually be valid URLs; in
+Strings passed to `dj_database_url` must be valid URLs; in
 particular, special characters must be url-encoded. The following url will raise
 a `ValueError`::
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,15 @@ and is available in Django 1.6+. If you do not set a value, it will default to `
 which is Django's historical behavior of using a new database connection on each
 request. Use ``None`` for unlimited persistent connections.
 
+Strings passed to `dj_database_url` must actually be valid URLs; in
+particular, special characters must be url-encoded. The following url will raise
+a `ValueError`
+
+    postgres://user:p#ssword!@localhost/foobar
+
+and should instead be passed as
+
+    postgres://user:p%23ssword!@localhost/foobar
 
 """
 

--- a/setup.py
+++ b/setup.py
@@ -54,11 +54,11 @@ request. Use ``None`` for unlimited persistent connections.
 
 Strings passed to `dj_database_url` must actually be valid URLs; in
 particular, special characters must be url-encoded. The following url will raise
-a `ValueError`
+a `ValueError`::
 
     postgres://user:p#ssword!@localhost/foobar
 
-and should instead be passed as
+and should instead be passed as::
 
     postgres://user:p%23ssword!@localhost/foobar
 

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -336,6 +336,19 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['OPTIONS']['driver'] == 'ODBC Driver 13 for SQL Server'
         assert 'currentSchema' not in url['OPTIONS']
 
+    def test_invalid_url_raises_valueerror(self):
+        url = 'postgres://user:p#ssword!@localhost/foobar'
+
+        with self.assertRaises(ValueError):
+            dj_database_url.parse(url)
+
+    def test_encoded_url(self):
+        url = 'postgres://user%40domain:p%23ssword!@localhost/foobar'
+        url = dj_database_url.parse(url)
+
+        assert url['USER'] == 'user@domain'
+        assert url['PASSWORD'] == 'p#ssword!'
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #108 by adding adding a more explicit exception message when a invalid URL is provided. Also, adds documentation tests to make explicit that special characters must be url-encoded.