### PR TITLE
Use urlsplit() instead of urlparse()

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -70,7 +70,7 @@ def parse(url, engine=None, conn_max_age=0, ssl_require=False):
     # otherwise parse the url as normal
     parsed_config = {}
 
-    url = urlparse.urlparse(url)
+    url = urlparse.urlsplit(url)
 
     # Split query strings from path.
     path = url.path[1:]


### PR DESCRIPTION
[`urlparse()`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse) allows for “parameters” before the `?` in the URL. dj-database-url does not use these parameters.

[`urlsplit()`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlsplit) supports a later (1998) RFC and does not parse such parameters. It's thus a bit faster.

Anthony Sottile did a [video on the subject](https://www.youtube.com/watch?v=ABJvdsIANds), which taught me about this difference, and I merged a similar change to django-cors-headers: https://github.com/adamchainz/django-cors-headers/pull/793