### PR TITLE
Include the test suite in sdist archive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include py.typed
+include test_dj_database_url.py


### PR DESCRIPTION
Include the test suite in sdist archive so that it could be used by packagers (Linux distributions, Conda) that wish to run tests.