### PR TITLE
docs: use `variable` instead of `setting`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Usage
           ),
       }
 
-- You can provide a default, used if the ``DATABASE_URL`` setting is not defined:
+- You can provide a default, used if the ``DATABASE_URL`` variable is not defined:
 
   .. code-block:: python
 


### PR DESCRIPTION
I'm not a Python/Django dev by trade and this could be why it stands out to me so much, but I feel like there is an important difference between "variable" and "setting" since this is expected to be in `settings.py`.