### PR TITLE
Do not leak `key` loop variable into global namespace

### DIFF
--- a/dj_database_url/__init__.py
+++ b/dj_database_url/__init__.py
@@ -31,6 +31,7 @@ SCHEMES = {
 # Register database schemes in URLs.
 for key in SCHEMES.keys():
     urlparse.uses_netloc.append(key)
+del key
 
 
 # From https://docs.djangoproject.com/en/4.0/ref/settings/#databases


### PR DESCRIPTION
This is a common problem for module level loops / helpers / etc.

`key` is importable name, it is even imported when using `from dj_database_url import *`. This is clearly not what we want.