### PR TITLE
Add disable_server_side_cursors parameter

### DIFF
--- a/dj_database_url/__init__.py
+++ b/dj_database_url/__init__.py
@@ -58,6 +58,7 @@ def config(
     engine: Optional[str] = None,
     conn_max_age: Optional[int] = 0,
     conn_health_checks: bool = False,
+    disable_server_side_cursors: bool = False,
     ssl_require: bool = False,
     test_options: Optional[Dict] = None,
 ) -> DBConfig:
@@ -71,7 +72,13 @@ def config(
 
     if s:
         return parse(
-            s, engine, conn_max_age, conn_health_checks, ssl_require, test_options
+            s,
+            engine,
+            conn_max_age,
+            conn_health_checks,
+            disable_server_side_cursors,
+            ssl_require,
+            test_options,
         )
 
     return {}
@@ -82,6 +89,7 @@ def parse(
     engine: Optional[str] = None,
     conn_max_age: Optional[int] = 0,
     conn_health_checks: bool = False,
+    disable_server_side_cursors: bool = False,
     ssl_require: bool = False,
     test_options: Optional[dict] = None,
 ) -> DBConfig:
@@ -146,6 +154,7 @@ def parse(
             "PORT": port or "",
             "CONN_MAX_AGE": conn_max_age,
             "CONN_HEALTH_CHECKS": conn_health_checks,
+            "DISABLE_SERVER_SIDE_CURSORS": disable_server_side_cursors,
             "ENGINE": engine,
         }
     )

--- a/tests/test_dj_database_url.py
+++ b/tests/test_dj_database_url.py
@@ -592,6 +592,15 @@ class DatabaseTestSuite(unittest.TestCase):
         )
         assert url["OPTIONS"] == {'connect_timout': 3}
 
+    @mock.patch.dict(
+        os.environ,
+        {"DATABASE_URL": "postgres://user:password@instance.amazonaws.com:5431/d8r8?"},
+    )
+    def test_server_side_cursors__config(self):
+        url = dj_database_url.config(disable_server_side_cursors=True)
+
+        assert url["DISABLE_SERVER_SIDE_CURSORS"] is True
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi there,

I noticed that I couldn't properly set the DISABLE_SERVER_SIDE_CURSORS database settings. So this PR adds it as a parameter, akin to the conn_max_age or conn_health_checks variable.