### PR TITLE
Make config test options not unknown types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,10 @@ jobs:
           pip install -r requirements.txt
           pip install "Django~=${{ matrix.django-version }}.0" .
 
-      - name: Run mypy
+      - name: Run type checking
         run: |
           python -m mypy dj_database_url
+          python -m pyright dj_database_url
 
       - name: Run Tests
         run: |
@@ -52,8 +53,9 @@ jobs:
 
       - uses: codecov/codecov-action@v3
 
-      - name: Check mypy types installation
+      - name: Check types installation
         run: |
           pip install .
           cd tests
           python -m mypy .
+          python -m pyright .

--- a/dj_database_url/__init__.py
+++ b/dj_database_url/__init__.py
@@ -70,7 +70,7 @@ def config(
     conn_health_checks: bool = False,
     disable_server_side_cursors: bool = False,
     ssl_require: bool = False,
-    test_options: Optional[Dict] = None,
+    test_options: Optional[Dict[str, Any]] = None,
 ) -> DBConfig:
     """Returns configured DATABASE dictionary from DATABASE_URL."""
     s = os.environ.get(env, default)
@@ -101,7 +101,7 @@ def parse(
     conn_health_checks: bool = False,
     disable_server_side_cursors: bool = False,
     ssl_require: bool = False,
-    test_options: Optional[dict] = None,
+    test_options: Optional[Dict[str, Any]] = None,
 ) -> DBConfig:
     """Parses a database URL."""
     if url == "sqlite://:memory:":

--- a/dj_database_url/__init__.py
+++ b/dj_database_url/__init__.py
@@ -41,7 +41,7 @@ SCHEMES_WITH_SEARCH_PATH = [
 # Register database schemes in URLs.
 for key in SCHEMES.keys():
     urlparse.uses_netloc.append(key)
-del key
+del key  # pyright: ignore[reportPossiblyUnboundVariable]
 
 
 # From https://docs.djangoproject.com/en/4.0/ref/settings/#databases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ show_error_codes=true
 disallow_untyped_defs=true
 disallow_untyped_calls=true
 warn_redundant_casts=true
+
+[tool.pyright]
+typeCheckingMode = "strict"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 coverage
 mypy
+pyright

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from setuptools import setup
+from setuptools import setup  # pyright: ignore[reportUnknownVariableType]
 
 readme = Path("README.rst").read_text()
 

--- a/tests/test_dj_database_url.py
+++ b/tests/test_dj_database_url.py
@@ -1,3 +1,5 @@
+# pyright: reportTypedDictNotRequiredAccess=false
+
 import os
 import unittest
 from unittest import mock


### PR DESCRIPTION
pyright in strict mode complains about the test options having an unknown type, which this fixes

> `/home/palfrey/src/sked/sked/settings.py:89:16 - error: Type of "config" is partially unknown`
> ```Type of "config" is "(env: str = DEFAULT_ENV, default: str | None = None, engine: str | None = None, conn_max_age: int | None = 0, conn_health_checks: bool = False, disable_server_side_cursors: bool = False, ssl_require: bool = False, test_options: Dict[Unknown, Unknown] | None = None) -> DBConfig" (reportUnknownMemberType)```

This also explicitly adds pyright support to the CI to avoid this happening again