### PR TITLE
Drop dependency on `typing_extensions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+* Drop dependency on `typing_extensions`.
+
 ## v2.3.0 (2024-10-23)
 * Remove Python 3.8 support.
 * Remove Django 3 support.

--- a/dj_database_url/__init__.py
+++ b/dj_database_url/__init__.py
@@ -1,9 +1,7 @@
 import logging
 import os
 import urllib.parse as urlparse
-from typing import Any, Dict, Optional, Union
-
-from typing_extensions import TypedDict
+from typing import Any, Dict, Optional, TypedDict, Union
 
 DEFAULT_ENV = "DATABASE_URL"
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description=readme,
     long_description_content_type="text/x-rst",
     packages=["dj_database_url"],
-    install_requires=["Django>=4.2", "typing_extensions >= 3.10.0.0"],
+    install_requires=["Django>=4.2"],
     include_package_data=True,
     package_data={
         "dj_database_url": ["py.typed"],


### PR DESCRIPTION
Since it was only being used for `TypedDict`, which was added in Python 3.8 and `dj-database-url` v2.3.0+ only supports Python 3.9+.

See:
https://docs.python.org/3.12/library/typing.html#typing.TypedDict
https://github.com/jazzband/dj-database-url/blob/master/CHANGELOG.md#v230-2024-10-23