### PR TITLE
Fix type errors

### DIFF
--- a/tests/test_dj_database_url.py
+++ b/tests/test_dj_database_url.py
@@ -10,9 +10,10 @@ POSTGIS_URL = "postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compu
 
 
 class DatabaseTestSuite(unittest.TestCase):
-    def test_postgres_parsing(self):
-        url = "postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_postgres_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "django.db.backends.postgresql"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -21,9 +22,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "wegauwhgeuioweg"
         assert url["PORT"] == 5431
 
-    def test_postgres_unix_socket_parsing(self):
-        url = "postgres://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_postgres_unix_socket_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "postgres://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "django.db.backends.postgresql"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -32,8 +34,9 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == ""
         assert url["PORT"] == ""
 
-        url = "postgres://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+        url = dj_database_url.parse(
+            "postgres://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "django.db.backends.postgresql"
         assert url["HOST"] == "/Users/postgres/RuN"
@@ -41,9 +44,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == ""
         assert url["PORT"] == ""
 
-    def test_postgres_google_cloud_parsing(self):
-        url = "postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@%2Fcloudsql%2Fproject_id%3Aregion%3Ainstance_id/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_postgres_google_cloud_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@%2Fcloudsql%2Fproject_id%3Aregion%3Ainstance_id/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "django.db.backends.postgresql"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -52,9 +56,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "wegauwhgeuioweg"
         assert url["PORT"] == ""
 
-    def test_ipv6_parsing(self):
-        url = "postgres://ieRaekei9wilaim7:wegauwhgeuioweg@[2001:db8:1234::1234:5678:90af]:5431/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_ipv6_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "postgres://ieRaekei9wilaim7:wegauwhgeuioweg@[2001:db8:1234::1234:5678:90af]:5431/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "django.db.backends.postgresql"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -63,9 +68,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "wegauwhgeuioweg"
         assert url["PORT"] == 5431
 
-    def test_postgres_search_path_parsing(self):
-        url = "postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema"
-        url = dj_database_url.parse(url)
+    def test_postgres_search_path_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema"
+        )
         assert url["ENGINE"] == "django.db.backends.postgresql"
         assert url["NAME"] == "d8r82722r2kuvn"
         assert url["HOST"] == "ec2-107-21-253-135.compute-1.amazonaws.com"
@@ -75,9 +81,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["OPTIONS"]["options"] == "-c search_path=otherschema"
         assert "currentSchema" not in url["OPTIONS"]
 
-    def test_postgres_parsing_with_special_characters(self):
-        url = "postgres://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database"
-        url = dj_database_url.parse(url)
+    def test_postgres_parsing_with_special_characters(self) -> None:
+        url = dj_database_url.parse(
+            "postgres://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database"
+        )
 
         assert url["ENGINE"] == "django.db.backends.postgresql"
         assert url["NAME"] == "#database"
@@ -86,9 +93,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "#password"
         assert url["PORT"] == 5431
 
-    def test_postgres_parsing_with_int_bool_str_query_string(self):
-        url = "postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?server_side_binding=true&timeout=20&service=my_service&passfile=.my_pgpass"
-        url = dj_database_url.parse(url)
+    def test_postgres_parsing_with_int_bool_str_query_string(self) -> None:
+        url = dj_database_url.parse(
+            "postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?server_side_binding=true&timeout=20&service=my_service&passfile=.my_pgpass"
+        )
 
         assert url["ENGINE"] == "django.db.backends.postgresql"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -101,9 +109,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["OPTIONS"]["service"] == "my_service"
         assert url["OPTIONS"]["passfile"] == ".my_pgpass"
 
-    def test_postgis_parsing(self):
-        url = "postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_postgis_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "django.contrib.gis.db.backends.postgis"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -112,9 +121,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "wegauwhgeuioweg"
         assert url["PORT"] == 5431
 
-    def test_postgis_search_path_parsing(self):
-        url = "postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema"
-        url = dj_database_url.parse(url)
+    def test_postgis_search_path_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema"
+        )
         assert url["ENGINE"] == "django.contrib.gis.db.backends.postgis"
         assert url["NAME"] == "d8r82722r2kuvn"
         assert url["HOST"] == "ec2-107-21-253-135.compute-1.amazonaws.com"
@@ -124,9 +134,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["OPTIONS"]["options"] == "-c search_path=otherschema"
         assert "currentSchema" not in url["OPTIONS"]
 
-    def test_mysql_gis_parsing(self):
-        url = "mysqlgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_mysql_gis_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "mysqlgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "django.contrib.gis.db.backends.mysql"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -135,9 +146,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "wegauwhgeuioweg"
         assert url["PORT"] == 5431
 
-    def test_mysql_connector_parsing(self):
-        url = "mysql-connector://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_mysql_connector_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "mysql-connector://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "mysql.connector.django"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -146,7 +158,7 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "wegauwhgeuioweg"
         assert url["PORT"] == 5431
 
-    def test_config_test_options(self):
+    def test_config_test_options(self) -> None:
         with mock.patch.dict(
             os.environ,
             {
@@ -160,9 +172,10 @@ class DatabaseTestSuite(unittest.TestCase):
 
         assert url['TEST']['NAME'] == 'mytestdatabase'
 
-    def test_cleardb_parsing(self):
-        url = "mysql://bea6eb025ca0d8:69772142@us-cdbr-east.cleardb.com/heroku_97681db3eff7580?reconnect=true"
-        url = dj_database_url.parse(url)
+    def test_cleardb_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "mysql://bea6eb025ca0d8:69772142@us-cdbr-east.cleardb.com/heroku_97681db3eff7580?reconnect=true"
+        )
 
         assert url["ENGINE"] == "django.db.backends.mysql"
         assert url["NAME"] == "heroku_97681db3eff7580"
@@ -171,7 +184,7 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "69772142"
         assert url["PORT"] == ""
 
-    def test_database_url(self):
+    def test_database_url(self) -> None:
         with mock.patch.dict(os.environ, clear=True):
             a = dj_database_url.config()
         assert not a
@@ -191,28 +204,28 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "wegauwhgeuioweg"
         assert url["PORT"] == 5431
 
-    def test_empty_sqlite_url(self):
-        url = "sqlite://"
-        url = dj_database_url.parse(url)
+    def test_empty_sqlite_url(self) -> None:
+        url = dj_database_url.parse("sqlite://")
 
         assert url["ENGINE"] == "django.db.backends.sqlite3"
         assert url["NAME"] == ":memory:"
 
-    def test_memory_sqlite_url(self):
-        url = "sqlite://:memory:"
-        url = dj_database_url.parse(url)
+    def test_memory_sqlite_url(self) -> None:
+        url = dj_database_url.parse("sqlite://:memory:")
 
         assert url["ENGINE"] == "django.db.backends.sqlite3"
         assert url["NAME"] == ":memory:"
 
-    def test_parse_engine_setting(self):
+    def test_parse_engine_setting(self) -> None:
         engine = "django_mysqlpool.backends.mysqlpool"
-        url = "mysql://bea6eb025ca0d8:69772142@us-cdbr-east.cleardb.com/heroku_97681db3eff7580?reconnect=true"
-        url = dj_database_url.parse(url, engine)
+        url = dj_database_url.parse(
+            "mysql://bea6eb025ca0d8:69772142@us-cdbr-east.cleardb.com/heroku_97681db3eff7580?reconnect=true",
+            engine,
+        )
 
         assert url["ENGINE"] == engine
 
-    def test_config_engine_setting(self):
+    def test_config_engine_setting(self) -> None:
         engine = "django_mysqlpool.backends.mysqlpool"
         with mock.patch.dict(
             os.environ,
@@ -224,14 +237,16 @@ class DatabaseTestSuite(unittest.TestCase):
 
         assert url["ENGINE"] == engine
 
-    def test_parse_conn_max_age_setting(self):
+    def test_parse_conn_max_age_setting(self) -> None:
         conn_max_age = 600
-        url = "mysql://bea6eb025ca0d8:69772142@us-cdbr-east.cleardb.com/heroku_97681db3eff7580?reconnect=true"
-        url = dj_database_url.parse(url, conn_max_age=conn_max_age)
+        url = dj_database_url.parse(
+            "mysql://bea6eb025ca0d8:69772142@us-cdbr-east.cleardb.com/heroku_97681db3eff7580?reconnect=true",
+            conn_max_age=conn_max_age,
+        )
 
         assert url["CONN_MAX_AGE"] == conn_max_age
 
-    def test_config_conn_max_age_setting(self):
+    def test_config_conn_max_age_setting(self) -> None:
         conn_max_age = 600
         with mock.patch.dict(
             os.environ,
@@ -243,7 +258,7 @@ class DatabaseTestSuite(unittest.TestCase):
 
         assert url["CONN_MAX_AGE"] == conn_max_age
 
-    def test_database_url_with_options(self):
+    def test_database_url_with_options(self) -> None:
         # Test full options
         with mock.patch.dict(
             os.environ,
@@ -274,7 +289,7 @@ class DatabaseTestSuite(unittest.TestCase):
             url = dj_database_url.config()
         assert "OPTIONS" not in url
 
-    def test_mysql_database_url_with_sslca_options(self):
+    def test_mysql_database_url_with_sslca_options(self) -> None:
         with mock.patch.dict(
             os.environ,
             {
@@ -301,9 +316,8 @@ class DatabaseTestSuite(unittest.TestCase):
             url = dj_database_url.config()
         assert "OPTIONS" not in url
 
-    def test_oracle_parsing(self):
-        url = "oracle://scott:tiger@oraclehost:1521/hr"
-        url = dj_database_url.parse(url)
+    def test_oracle_parsing(self) -> None:
+        url = dj_database_url.parse("oracle://scott:tiger@oraclehost:1521/hr")
 
         assert url["ENGINE"] == "django.db.backends.oracle"
         assert url["NAME"] == "hr"
@@ -312,9 +326,8 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "tiger"
         assert url["PORT"] == "1521"
 
-    def test_oracle_gis_parsing(self):
-        url = "oraclegis://scott:tiger@oraclehost:1521/hr"
-        url = dj_database_url.parse(url)
+    def test_oracle_gis_parsing(self) -> None:
+        url = dj_database_url.parse("oraclegis://scott:tiger@oraclehost:1521/hr")
 
         assert url["ENGINE"] == "django.contrib.gis.db.backends.oracle"
         assert url["NAME"] == "hr"
@@ -323,14 +336,13 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "tiger"
         assert url["PORT"] == 1521
 
-    def test_oracle_dsn_parsing(self):
-        url = (
+    def test_oracle_dsn_parsing(self) -> None:
+        url = dj_database_url.parse(
             "oracle://scott:tiger@/"
             "(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)"
             "(HOST=oraclehost)(PORT=1521)))"
             "(CONNECT_DATA=(SID=hr)))"
         )
-        url = dj_database_url.parse(url)
 
         assert url["ENGINE"] == "django.db.backends.oracle"
         assert url["USER"] == "scott"
@@ -346,9 +358,8 @@ class DatabaseTestSuite(unittest.TestCase):
 
         assert url["NAME"] == dsn
 
-    def test_oracle_tns_parsing(self):
-        url = "oracle://scott:tiger@/tnsname"
-        url = dj_database_url.parse(url)
+    def test_oracle_tns_parsing(self) -> None:
+        url = dj_database_url.parse("oracle://scott:tiger@/tnsname")
 
         assert url["ENGINE"] == "django.db.backends.oracle"
         assert url["USER"] == "scott"
@@ -357,9 +368,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["HOST"] == ""
         assert url["PORT"] == ""
 
-    def test_redshift_parsing(self):
-        url = "redshift://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5439/d8r82722r2kuvn?currentSchema=otherschema"
-        url = dj_database_url.parse(url)
+    def test_redshift_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "redshift://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5439/d8r82722r2kuvn?currentSchema=otherschema"
+        )
 
         assert url["ENGINE"] == "django_redshift_backend"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -370,9 +382,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["OPTIONS"]["options"] == "-c search_path=otherschema"
         assert "currentSchema" not in url["OPTIONS"]
 
-    def test_mssql_parsing(self):
-        url = "mssql://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com/d8r82722r2kuvn?driver=ODBC Driver 13 for SQL Server"
-        url = dj_database_url.parse(url)
+    def test_mssql_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "mssql://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com/d8r82722r2kuvn?driver=ODBC Driver 13 for SQL Server"
+        )
 
         assert url["ENGINE"] == "sql_server.pyodbc"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -383,9 +396,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["OPTIONS"]["driver"] == "ODBC Driver 13 for SQL Server"
         assert "currentSchema" not in url["OPTIONS"]
 
-    def test_mssql_instance_port_parsing(self):
-        url = "mssql://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com\\insnsnss:12345/d8r82722r2kuvn?driver=ODBC Driver 13 for SQL Server"
-        url = dj_database_url.parse(url)
+    def test_mssql_instance_port_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "mssql://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com\\insnsnss:12345/d8r82722r2kuvn?driver=ODBC Driver 13 for SQL Server"
+        )
 
         assert url["ENGINE"] == "sql_server.pyodbc"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -396,9 +410,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["OPTIONS"]["driver"] == "ODBC Driver 13 for SQL Server"
         assert "currentSchema" not in url["OPTIONS"]
 
-    def test_cockroach(self):
-        url = "cockroach://testuser:testpass@testhost:26257/cockroach?sslmode=verify-full&sslrootcert=/certs/ca.crt&sslcert=/certs/client.myprojectuser.crt&sslkey=/certs/client.myprojectuser.key"
-        url = dj_database_url.parse(url)
+    def test_cockroach(self) -> None:
+        url = dj_database_url.parse(
+            "cockroach://testuser:testpass@testhost:26257/cockroach?sslmode=verify-full&sslrootcert=/certs/ca.crt&sslcert=/certs/client.myprojectuser.crt&sslkey=/certs/client.myprojectuser.key"
+        )
         assert url['ENGINE'] == 'django_cockroachdb'
         assert url['NAME'] == 'cockroach'
         assert url['HOST'] == 'testhost'
@@ -410,9 +425,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['OPTIONS']['sslcert'] == '/certs/client.myprojectuser.crt'
         assert url['OPTIONS']['sslkey'] == '/certs/client.myprojectuser.key'
 
-    def test_mssqlms_parsing(self):
-        url = "mssqlms://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com/d8r82722r2kuvn?driver=ODBC Driver 13 for SQL Server"
-        url = dj_database_url.parse(url)
+    def test_mssqlms_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "mssqlms://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com/d8r82722r2kuvn?driver=ODBC Driver 13 for SQL Server"
+        )
 
         assert url["ENGINE"] == "mssql"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -423,9 +439,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["OPTIONS"]["driver"] == "ODBC Driver 13 for SQL Server"
         assert "currentSchema" not in url["OPTIONS"]
 
-    def test_timescale_parsing(self):
-        url = "timescale://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_timescale_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "timescale://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "timescale.db.backends.postgresql"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -434,9 +451,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "wegauwhgeuioweg"
         assert url["PORT"] == 5431
 
-    def test_timescale_unix_socket_parsing(self):
-        url = "timescale://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_timescale_unix_socket_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "timescale://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "timescale.db.backends.postgresql"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -445,8 +463,9 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == ""
         assert url["PORT"] == ""
 
-        url = "timescale://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+        url = dj_database_url.parse(
+            "timescale://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "timescale.db.backends.postgresql"
         assert url["HOST"] == "/Users/postgres/RuN"
@@ -454,9 +473,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == ""
         assert url["PORT"] == ""
 
-    def test_timescale_ipv6_parsing(self):
-        url = "timescale://ieRaekei9wilaim7:wegauwhgeuioweg@[2001:db8:1234::1234:5678:90af]:5431/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_timescale_ipv6_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "timescale://ieRaekei9wilaim7:wegauwhgeuioweg@[2001:db8:1234::1234:5678:90af]:5431/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "timescale.db.backends.postgresql"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -465,9 +485,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "wegauwhgeuioweg"
         assert url["PORT"] == 5431
 
-    def test_timescale_search_path_parsing(self):
-        url = "timescale://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema"
-        url = dj_database_url.parse(url)
+    def test_timescale_search_path_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "timescale://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema"
+        )
         assert url["ENGINE"] == "timescale.db.backends.postgresql"
         assert url["NAME"] == "d8r82722r2kuvn"
         assert url["HOST"] == "ec2-107-21-253-135.compute-1.amazonaws.com"
@@ -477,9 +498,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["OPTIONS"]["options"] == "-c search_path=otherschema"
         assert "currentSchema" not in url["OPTIONS"]
 
-    def test_timescale_parsing_with_special_characters(self):
-        url = "timescale://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database"
-        url = dj_database_url.parse(url)
+    def test_timescale_parsing_with_special_characters(self) -> None:
+        url = dj_database_url.parse(
+            "timescale://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database"
+        )
 
         assert url["ENGINE"] == "timescale.db.backends.postgresql"
         assert url["NAME"] == "#database"
@@ -488,9 +510,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "#password"
         assert url["PORT"] == 5431
 
-    def test_timescalegis_parsing(self):
-        url = "timescalegis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_timescalegis_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "timescalegis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "timescale.db.backends.postgis"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -499,9 +522,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "wegauwhgeuioweg"
         assert url["PORT"] == 5431
 
-    def test_timescalegis_unix_socket_parsing(self):
-        url = "timescalegis://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_timescalegis_unix_socket_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "timescalegis://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "timescale.db.backends.postgis"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -510,8 +534,9 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == ""
         assert url["PORT"] == ""
 
-        url = "timescalegis://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+        url = dj_database_url.parse(
+            "timescalegis://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "timescale.db.backends.postgis"
         assert url["HOST"] == "/Users/postgres/RuN"
@@ -519,9 +544,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == ""
         assert url["PORT"] == ""
 
-    def test_timescalegis_ipv6_parsing(self):
-        url = "timescalegis://ieRaekei9wilaim7:wegauwhgeuioweg@[2001:db8:1234::1234:5678:90af]:5431/d8r82722r2kuvn"
-        url = dj_database_url.parse(url)
+    def test_timescalegis_ipv6_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "timescalegis://ieRaekei9wilaim7:wegauwhgeuioweg@[2001:db8:1234::1234:5678:90af]:5431/d8r82722r2kuvn"
+        )
 
         assert url["ENGINE"] == "timescale.db.backends.postgis"
         assert url["NAME"] == "d8r82722r2kuvn"
@@ -530,9 +556,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "wegauwhgeuioweg"
         assert url["PORT"] == 5431
 
-    def test_timescalegis_search_path_parsing(self):
-        url = "timescalegis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema"
-        url = dj_database_url.parse(url)
+    def test_timescalegis_search_path_parsing(self) -> None:
+        url = dj_database_url.parse(
+            "timescalegis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema"
+        )
         assert url["ENGINE"] == "timescale.db.backends.postgis"
         assert url["NAME"] == "d8r82722r2kuvn"
         assert url["HOST"] == "ec2-107-21-253-135.compute-1.amazonaws.com"
@@ -542,9 +569,10 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["OPTIONS"]["options"] == "-c search_path=otherschema"
         assert "currentSchema" not in url["OPTIONS"]
 
-    def test_timescalegis_parsing_with_special_characters(self):
-        url = "timescalegis://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database"
-        url = dj_database_url.parse(url)
+    def test_timescalegis_parsing_with_special_characters(self) -> None:
+        url = dj_database_url.parse(
+            "timescalegis://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database"
+        )
 
         assert url["ENGINE"] == "timescale.db.backends.postgis"
         assert url["NAME"] == "#database"
@@ -553,7 +581,7 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["PASSWORD"] == "#password"
         assert url["PORT"] == 5431
 
-    def test_persistent_connection_variables(self):
+    def test_persistent_connection_variables(self) -> None:
         url = dj_database_url.parse(
             "sqlite://myfile.db", conn_max_age=600, conn_health_checks=True
         )
@@ -561,7 +589,7 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["CONN_MAX_AGE"] == 600
         assert url["CONN_HEALTH_CHECKS"] is True
 
-    def test_sqlite_memory_persistent_connection_variables(self):
+    def test_sqlite_memory_persistent_connection_variables(self) -> None:
         # memory sqlite ignores connection.close(), so persistent connection
         # variables aren’t required
         url = dj_database_url.parse(
@@ -575,13 +603,13 @@ class DatabaseTestSuite(unittest.TestCase):
         os.environ,
         {"DATABASE_URL": "postgres://user:password@instance.amazonaws.com:5431/d8r8?"},
     )
-    def test_persistent_connection_variables_config(self):
+    def test_persistent_connection_variables_config(self) -> None:
         url = dj_database_url.config(conn_max_age=600, conn_health_checks=True)
 
         assert url["CONN_MAX_AGE"] == 600
         assert url["CONN_HEALTH_CHECKS"] is True
 
-    def test_no_env_variable(self):
+    def test_no_env_variable(self) -> None:
         with self.assertLogs() as cm:
             with mock.patch.dict(os.environ, clear=True):
                 url = dj_database_url.config()
@@ -590,7 +618,7 @@ class DatabaseTestSuite(unittest.TestCase):
             'WARNING:root:No DATABASE_URL environment variable set, and so no databases setup'
         ], cm.output
 
-    def test_bad_url_parsing(self):
+    def test_bad_url_parsing(self) -> None:
         with self.assertRaisesRegex(ValueError, "No support for 'foo'. We support: "):
             dj_database_url.parse("foo://bar")
 
@@ -598,11 +626,11 @@ class DatabaseTestSuite(unittest.TestCase):
         os.environ,
         {"DATABASE_URL": "postgres://user:password@instance.amazonaws.com:5431/d8r8?"},
     )
-    def test_ssl_require(self):
+    def test_ssl_require(self) -> None:
         url = dj_database_url.config(ssl_require=True)
         assert url["OPTIONS"] == {'sslmode': 'require'}
 
-    def test_options_int_values(self):
+    def test_options_int_values(self) -> None:
         """Ensure that options with integer values are parsed correctly."""
         url = dj_database_url.parse(
             "mysql://user:pw@127.0.0.1:15036/db?connect_timout=3"
@@ -613,7 +641,7 @@ class DatabaseTestSuite(unittest.TestCase):
         os.environ,
         {"DATABASE_URL": "postgres://user:password@instance.amazonaws.com:5431/d8r8?"},
     )
-    def test_server_side_cursors__config(self):
+    def test_server_side_cursors__config(self) -> None:
         url = dj_database_url.config(disable_server_side_cursors=True)
 
         assert url["DISABLE_SERVER_SIDE_CURSORS"] is True


### PR DESCRIPTION
First, Mypy reported a lot of issues for the tests not including  `-> None` annotations. After adding them, there were lots of issues due to the `url` variables being reassigned from `str` to `DBConfig` objects, fixed by inlining the URLs into the `parse()` calls.

Extracted from #260.