### PR TITLE
Use typing.Dict type

### DIFF
--- a/dj_database_url/__init__.py
+++ b/dj_database_url/__init__.py
@@ -235,7 +235,7 @@ def _convert_to_settings(
     conn_health_checks: bool,
     disable_server_side_cursors: bool,
     ssl_require: bool,
-    test_options: Optional[dict[str, Any]],
+    test_options: Optional[Dict[str, Any]],
 ) -> DBConfig:
     settings: DBConfig = {
         "CONN_MAX_AGE": conn_max_age,


### PR DESCRIPTION
15ac40b0a78484575cb41f7a1e1ab6cdceea9e3a had added a `Optional[dict[str, Any]]` annotation (notice the non-capital `d`), which inadvertently caused this project to not be compatible with Python 3.8, where `dict` the type is not subscriptable until 3.9, which causes build problems in downstream packages since there is no official `requires_python` marker in the package metadata for 3.x, so old Pythons will happily try to install the newer versions.

This PR applies the minimal fix for this that makes this package again importable on Python 3.8 – I would recommend releasing this as dj-database-url==3.0.2 to minimize downstream user misery, then follow up with fixing things properly.