### PR TITLE
Remove obsolete license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",


### PR DESCRIPTION
The license is already declared via SPDX (PEP 639); license Trove classifiers must not be used in that case.

See https://peps.python.org/pep-0639/#deprecate-license-classifiers