### PR TITLE
Add tests directory to source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ build-backend = "uv_build"
 [tool.uv.build-backend]
 module-name = "dj_database_url"
 module-root = ""
-source-include = ["dj_database_url/py.typed"]
+source-include = ["dj_database_url/py.typed", "tests"]
 
 [tool.black]
 skip-string-normalization = 1


### PR DESCRIPTION
Fixes the issue where the tests directory was missing from the 3.1.0 source distribution. I added "tests" to the source-include list in pyproject.toml since this project uses uv_build as the build backend. Verified locally.