### PR TITLE
Add project URLs to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,13 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 
+[project.urls]
+Homepage = "https://jazzband.co/projects/dj-database-url"
+Documentation = "https://github.com/jazzband/dj-database-url/blob/master/README.rst"
+Changelog = "https://github.com/jazzband/dj-database-url/blob/master/CHANGELOG.md"
+Funding = "https://psfmember.org/civicrm/contribute/transact/?reset=1&id=34"
+Source = "https://github.com/jazzband/dj-database-url"
+"Issue Tracker" = "https://github.com/jazzband/dj-database-url/issues"
 
 [build-system]
 requires = ["uv_build>=0.9.17,<0.10.0"]


### PR DESCRIPTION
This pull request includes metadata to be used by PyPI to display useful project URLs, as per the official pyproject.toml guides:

https://docs.pypi.org/project_metadata/

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels

After being integrated and published on PyPi, it will display something like this.

<img width="197" height="239" alt="image" src="https://github.com/user-attachments/assets/63556be3-fcfe-4603-8565-49d53c235ca8" />
