### PR TITLE
Update .pre-commit-config.yaml to use pinned version numbers.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 5ba58aca0bd5bc7c0e1c0fc45af2e88d6a2bde83  # frozen: v0.14.10
+    rev: v0.14.13
     hooks:
       - id: ruff-check
         args:
@@ -16,6 +16,6 @@ repos:
           - --quiet
 
   - repo: https://github.com/crate-ci/typos
-    rev: 2d0ce569feab1f8752f1dde43cc2f2aa53236e06  # frozen: v1.40.0
+    rev: v1.42.0
     hooks:
       - id: typos


### PR DESCRIPTION
Pin pre-commit to version tags over git hashes.