### PR TITLE
Give specific ruff version to avoid random failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,7 @@ jobs:
           python-version: "3.12"
 
       - name: Run ruff
-        run: uvx ruff check
-
+        run: uvx ruff@0.16.0 check
 
   typecheck:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.21
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args:

--- a/dj_database_url/__init__.py
+++ b/dj_database_url/__init__.py
@@ -7,6 +7,8 @@ from typing import Any, TypedDict
 DEFAULT_ENV = "DATABASE_URL"
 ENGINE_SCHEMES: dict[str, "Engine"] = {}
 
+logger = logging.getLogger(__name__)
+
 
 # From https://docs.djangoproject.com/en/stable/ref/settings/#databases
 class DBConfig(TypedDict, total=False):
@@ -138,9 +140,7 @@ def config(
     s = os.environ.get(env, default)
 
     if s is None:
-        logging.warning(
-            "No %s environment variable set, and so no databases setup", env
-        )
+        logger.warning("No %s environment variable set, and so no databases setup", env)
 
     if s:
         return parse(

--- a/tests/test_dj_database_url.py
+++ b/tests/test_dj_database_url.py
@@ -635,7 +635,7 @@ class DatabaseTestSuite(unittest.TestCase):
                 url = dj_database_url.config()
             assert url == {}, url
         assert cm.output == [
-            'WARNING:root:No DATABASE_URL environment variable set, and so no databases setup'
+            'WARNING:dj_database_url:No DATABASE_URL environment variable set, and so no databases setup'
         ], cm.output
 
     def test_credentials_unquoted__raise_value_error(self) -> None:


### PR DESCRIPTION
Avoids problems like https://github.com/jazzband/dj-database-url/actions/runs/30143756374/job/89641726395?pr=316 due to ruff releasing a new version