### PR TITLE
Escape the currentSchema value in the libpq options string

### DIFF
--- a/dj_database_url/__init__.py
+++ b/dj_database_url/__init__.py
@@ -53,6 +53,17 @@ class UnknownSchemeError(ValueError):
         )
 
 
+def _escape_libpq_option_value(value: str) -> str:
+    """Escape a value for the libpq ``options`` connection parameter.
+
+    libpq treats unescaped spaces in ``options`` as separators between
+    command-line arguments, so a value containing a space would otherwise be
+    read as further arguments rather than as part of this one. A backslash
+    escapes the next character, and a doubled backslash is a literal one.
+    """
+    return value.replace("\\", "\\\\").replace(" ", "\\ ")
+
+
 def default_postprocess(parsed_config: DBConfig) -> None:
     pass
 
@@ -123,7 +134,8 @@ def apply_current_schema(parsed_config: DBConfig) -> None:
     options = parsed_config.get("OPTIONS", {})
     schema = options.pop("currentSchema", None)
     if schema:
-        options["options"] = f"-c search_path={schema}"
+        escaped = _escape_libpq_option_value(str(schema))
+        options["options"] = f"-c search_path={escaped}"
 
 
 def config(

--- a/tests/test_dj_database_url.py
+++ b/tests/test_dj_database_url.py
@@ -83,6 +83,25 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url["OPTIONS"]["options"] == "-c search_path=otherschema"
         assert "currentSchema" not in url["OPTIONS"]
 
+    def test_postgres_search_path_escapes_spaces(self) -> None:
+        # libpq splits the `options` string on unescaped spaces, so a schema
+        # name containing one must not be emitted as further arguments.
+        url = dj_database_url.parse(
+            "postgres://u:p@host:5431/db?currentSchema=my%20schema"
+        )
+        assert url["OPTIONS"]["options"] == "-c search_path=my\\ schema"
+
+    def test_postgres_search_path_escapes_backslashes(self) -> None:
+        url = dj_database_url.parse(
+            "postgres://u:p@host:5431/db?currentSchema=my%5Cschema"
+        )
+        assert url["OPTIONS"]["options"] == "-c search_path=my\\\\schema"
+
+    def test_postgres_search_path_accepts_non_string_values(self) -> None:
+        # digit-only query values are coerced to int before this hook runs
+        url = dj_database_url.parse("postgres://u:p@host:5431/db?currentSchema=123")
+        assert url["OPTIONS"]["options"] == "-c search_path=123"
+
     def test_postgres_parsing_with_special_characters(self) -> None:
         url = dj_database_url.parse(
             "postgres://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database"


### PR DESCRIPTION
## Description

`apply_current_schema` builds the libpq `options` connection parameter by
interpolating the `currentSchema` query value directly:

```python
options["options"] = f"-c search_path={schema}"
```

libpq treats unescaped spaces in `options` as separators between command-line
arguments:

> Specifies command-line options to send to the server at connection start. For
> example, setting this to `-c geqo=off` or `--geqo=off` sets the session's
> value of the `geqo` parameter to `off`. Spaces within this string are
> considered to separate command-line arguments, unless escaped with a
> backslash (`\`); write `\\` to represent a literal backslash.

So a schema value containing a space is not passed through as one `search_path`
value. It is read as additional arguments:

```python
>>> import dj_database_url
>>> dj_database_url.parse(
...     "postgres://u:p@host:5432/db?currentSchema=my%20schema"
... )["OPTIONS"]["options"]
'-c search_path=my schema'
```

libpq reads that as three arguments (`-c`, `search_path=my`, `schema`) rather
than the single `-c search_path=...` pair the code intends. The same applies to
any value containing a space, and a value containing `-c` can introduce further
settings.

This affects all seven schemes registered to this hook: `postgres`,
`postgresql`, `pgsql`, `postgis`, `redshift`, `timescale` and `timescalegis`.

To be clear about scope, this is a correctness issue rather than a security one.
Every query parameter is already mapped straight into `OPTIONS`, `options`
included, so whoever writes the URL can set libpq options directly regardless.
Escaping the value does not remove a capability; it makes the emitted string
match what this function is trying to produce.

The fix applies the escaping rule from the documentation above:

```python
def _escape_libpq_option_value(value: str) -> str:
    return value.replace("\\", "\\\\").replace(" ", "\\ ")
```

`str()` is applied to the value before escaping, because digit-only query values
are coerced to `int` by `_parse_value` before this hook runs, and would
otherwise not have a `.replace` method.

Behaviour after the change:

| `currentSchema` | emitted `options` |
|---|---|
| `otherschema` | `-c search_path=otherschema` (unchanged) |
| `my%20schema` | `-c search_path=my\ schema` |
| `my%5Cschema` | `-c search_path=my\\schema` |
| `123` | `-c search_path=123` (unchanged) |

Tests: three cases added next to the existing `currentSchema` tests, covering a
value with a space, a value with a backslash, and a digit-only value.

Validation: the suite goes from 54 passed to 57 passed, the three new cases
being the additions, with no existing test changed. The other CI checks pass on
the branch too: `ruff check` is clean, `mypy dj_database_url` reports
`Success: no issues found`, and `pyright dj_database_url` reports
`0 errors, 0 warnings`.