### PR TITLE
Escape all libpq option separators, not only spaces

### DIFF
--- a/dj_database_url/__init__.py
+++ b/dj_database_url/__init__.py
@@ -53,15 +53,27 @@ class UnknownSchemeError(ValueError):
         )
 
 
+#: Characters that terminate an argument in the libpq ``options`` string.
+#: PostgreSQL's ``pg_split_opts`` splits on ``isspace()``, which in the C
+#: locale is these six characters, so escaping the space alone is not enough.
+#: Non-ASCII whitespace needs no handling: ``isspace()`` is applied per byte,
+#: and a character such as U+00A0 encodes to 0xC2 0xA0, neither of which it
+#: matches.
+_LIBPQ_OPTION_SEPARATORS = " \t\n\v\f\r"
+
+
 def _escape_libpq_option_value(value: str) -> str:
     """Escape a value for the libpq ``options`` connection parameter.
 
-    libpq treats unescaped spaces in ``options`` as separators between
-    command-line arguments, so a value containing a space would otherwise be
-    read as further arguments rather than as part of this one. A backslash
+    libpq treats unescaped whitespace in ``options`` as separating
+    command-line arguments, so a value containing whitespace would otherwise
+    be read as further arguments rather than as part of this one. A backslash
     escapes the next character, and a doubled backslash is a literal one.
     """
-    return value.replace("\\", "\\\\").replace(" ", "\\ ")
+    value = value.replace("\\", "\\\\")
+    for separator in _LIBPQ_OPTION_SEPARATORS:
+        value = value.replace(separator, "\\" + separator)
+    return value
 
 
 def default_postprocess(parsed_config: DBConfig) -> None:

--- a/tests/test_dj_database_url.py
+++ b/tests/test_dj_database_url.py
@@ -4,7 +4,7 @@ import os
 import re
 import unittest
 from unittest import mock
-from urllib.parse import uses_netloc
+from urllib.parse import quote, uses_netloc
 
 import dj_database_url
 
@@ -101,6 +101,77 @@ class DatabaseTestSuite(unittest.TestCase):
         # digit-only query values are coerced to int before this hook runs
         url = dj_database_url.parse("postgres://u:p@host:5431/db?currentSchema=123")
         assert url["OPTIONS"]["options"] == "-c search_path=123"
+
+    def test_postgres_search_path_escapes_every_libpq_separator(self) -> None:
+        # `pg_split_opts` terminates an argument on isspace(), not on the space
+        # character alone, so every one of these must be escaped or it splits
+        # the options string and the rest is read as further arguments.
+        for encoded, raw in (
+            ("%20", " "),
+            ("%09", "\t"),
+            ("%0A", "\n"),
+            ("%0B", "\v"),
+            ("%0C", "\f"),
+            ("%0D", "\r"),
+        ):
+            with self.subTest(separator=repr(raw)):
+                url = dj_database_url.parse(
+                    f"postgres://u:p@host:5431/db?currentSchema=a{encoded}b"
+                )
+                assert url["OPTIONS"]["options"] == f"-c search_path=a\\{raw}b"
+
+    def test_postgres_search_path_survives_the_libpq_splitter(self) -> None:
+        # Round-trip against the rule `pg_split_opts` implements: whatever the
+        # schema name contains, the escaped string must come back out as
+        # exactly two arguments with the name intact.
+        separators = " \t\n\v\f\r"
+
+        def split_opts(optstr: str) -> list[str]:
+            # Port of `pg_split_opts`: arguments are separated by isspace(),
+            # which in the C locale is exactly `separators`, and a backslash
+            # escapes the character that follows it.
+            argv, index, length = [], 0, len(optstr)
+            while index < length:
+                while index < length and optstr[index] in separators:
+                    index += 1
+                if index >= length:
+                    break
+                current, escaped = [], False
+                while index < length:
+                    char = optstr[index]
+                    if char in separators and not escaped:
+                        break
+                    if not escaped and char == "\\":
+                        escaped = True
+                    else:
+                        escaped = False
+                        current.append(char)
+                    index += 1
+                argv.append("".join(current))
+            return argv
+
+        # the port reproduces pg_split_opts on inputs with known results
+        assert split_opts("") == []
+        assert split_opts("  -c  foo  ") == ["-c", "foo"]
+        assert split_opts("a\\ b") == ["a b"]
+
+        base = "postgres://u:p@host:5431/db?currentSchema="
+        for schema in (
+            "public",
+            "a b",
+            "a\tb",
+            "a\nb",
+            "a\vb",
+            "a\fb",
+            "a\rb",
+            "a\\b",
+            "a\\\tb",
+            "public,other",
+        ):
+            with self.subTest(schema=repr(schema)):
+                url = base + quote(schema, safe="")
+                options = dj_database_url.parse(url)["OPTIONS"]["options"]
+                assert split_opts(options) == ["-c", f"search_path={schema}"]
 
     def test_postgres_parsing_with_special_characters(self) -> None:
         url = dj_database_url.parse(


### PR DESCRIPTION
Follow-up to #321. That change escapes the space character in the
`currentSchema` value before interpolating it into the libpq `options`
parameter, following the documented rule that "Spaces within this string are
considered to separate command-line arguments". PostgreSQL's implementation is
broader than the documentation, so the escaping is incomplete.

`pg_split_opts` in `src/backend/utils/init/postinit.c` terminates an argument on
`isspace()`:

```c
while (isspace((unsigned char) *optstr))
    optstr++;
...
if (isspace((unsigned char) *optstr) && !last_was_escape)
    break;
```

In the C locale `isspace()` matches space, tab, newline, vertical tab, form feed
and carriage return. Only the first of those is currently escaped, so the other
five still split the option string.

Checked against current `master` with a port of `pg_split_opts`, using
`currentSchema=public<SEP>-c<SEP>log_statement=all`. A contained value yields the
two arguments `-c` and `search_path=...`; anything more is a second setting
reaching the server:

| separator | arguments produced |
|---|---|
| space | 2, contained |
| tab | 4 |
| newline | 4 |
| carriage return | 4 |
| vertical tab | 4 |
| form feed | 4 |

A value combining a backslash with a tab is also affected.

Same correctness class as #321 rather than a security issue: whoever writes the
database URL already controls the connection, so this grants no capability that
was not already available. It matters because a schema name should not be able
to become a separate server setting by accident.

This patch escapes every character `isspace()` matches, which closes the
remaining separators while leaving the existing behaviour for spaces and
backslashes unchanged:

```python
_LIBPQ_OPTION_SEPARATORS = " \t\n\v\f\r"
```

Non-ASCII whitespace does not need handling. PostgreSQL applies `isspace()` per
byte, and a character such as U+00A0 encodes to the bytes 0xC2 0xA0, neither of
which `isspace()` matches in the C locale.

Tests cover each separator individually and round-trip the escaped value through
a port of `pg_split_opts`, asserting it comes back as exactly two arguments with
the schema name intact, so a future change to the escaping cannot silently
reopen any one of them.
